### PR TITLE
style: home swipe image 영역 이슈 처리

### DIFF
--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -47,24 +47,24 @@ const Home = () => {
       <Container fluid>
         <Row xs={1}>
           <Col>
-            <HomeRow className="justify-content-center">
+            <HomeRow>
               <HomeCol xs={12}>
                 <SwipeImage title="정말싸다 뽀리 사진!!" src={BooriCat} onClick={onClickHandler} />
               </HomeCol>
             </HomeRow>
             <HomeRow>
               <HomeCol>
-                <div className="description">
+                <div className="subtitle">
                   이달의 아이템
                   <p>돈 많이 벌어서 고양이 까까 사주고 싶다.</p>
                 </div>
               </HomeCol>
             </HomeRow>
-            <Row>
+            <HomeRow>
               {productData.map((value, index) => {
                 return <ProductBox key={index} value={value} setClickData={setClickData} />
               })}
-            </Row>
+            </HomeRow>
           </Col>
         </Row>
       </Container>
@@ -77,8 +77,10 @@ export default Home
 const HomeCol = styled(Col)`
   justify-content: center;
 
-  & .description {
-    margin: 10px 0;
+  & .subtitle {
+    padding: 20px;
+    border-bottom: 1px #888888 solid;
+    border-top: 1px #888888 solid;
 
     p {
       color: #888888;
@@ -88,7 +90,7 @@ const HomeCol = styled(Col)`
 `
 
 const HomeRow = styled(Row)`
-  border-bottom: 1px #888888 solid;
+  padding: 10px;
 
   &:last-child {
     border: unset;
@@ -99,4 +101,5 @@ const SwipeImage = styled.img`
   width: 100%;
   height: 300px;
   object-fit: cover;
+  vertical-align: middle;
 `


### PR DESCRIPTION
상위 swipe img 하단부에 5.3사이즈의 공백 확인 됨

### 원인
이미지 높이를 300으로 고정하면서 vertical-align: middle의 기준점이 되는 부분이 틀어지며 발생한 스타일 이슈

### 해결 방법
img 사이즈 지정 부에서 vertical-align: middle 으로 위치 재지정 시 해결 되는 이슈 임을 확인

[before]
<img width="1025" alt="스크린샷 2023-04-28 오후 2 26 53" src="https://user-images.githubusercontent.com/67533804/235067103-7a90daa4-b38b-4f9b-9b49-c545912eed52.png">


[after]
<img width="1028" alt="스크린샷 2023-04-28 오후 2 32 00" src="https://user-images.githubusercontent.com/67533804/235067722-5a1bbdc3-cac0-4b04-b55d-b4bd696ba123.png">
